### PR TITLE
Increase sort indicator arrow size - Issue #19

### DIFF
--- a/CameraCopyTool/MainWindow.xaml
+++ b/CameraCopyTool/MainWindow.xaml
@@ -226,7 +226,7 @@
                                                       Margin="0,0,25,0"/>
                                     <TextBlock x:Name="SortIndicator"
                                                Text="▲"
-                                               FontSize="14"
+                                               FontSize="18"
                                                Foreground="#0D47A1"
                                                FontWeight="Bold"
                                                VerticalAlignment="Center"


### PR DESCRIPTION
✅ Committed and Pushed!

Pull Request - Issue #19
PR Title
Increase Sort Indicator Arrow Size - Issue #19
PR Description
## Summary
Increased the sort direction indicator arrow size from 14px to 18px (29% larger) to make it more visible and accessible for elderly users.

## Changes
### Implementation
- **MainWindow.xaml**: Increased `SortIndicator` TextBlock FontSize from 14 to 18

## User Impact
✅ **More visible sort indicators** - Arrow (▲/▼) is 29% larger  
✅ **Better accessibility** - Easier to see for users with vision changes  
✅ **Clearer UX** - Users can quickly identify which column is sorted  
✅ **No breaking changes** - Simple size increase, no layout impact  

## Accessibility Benefits
This change specifically helps:
- Elderly users (like Margaret, age 75) with age-related vision changes
- Users with mild visual impairments
- Anyone using the app on lower-resolution displays
- Users who prefer larger, more prominent UI elements

## Testing
- [x] Sort indicator arrow is visibly larger
- [x] No layout issues or text clipping
- [x] Works on all three ListViews (Already Copied, New Files, Destination)
- [x] Works for both ascending (▲) and descending (▼) indicators
- [x] Build succeeds without errors

## Related Issues
- Fixes #19 (partial - font size increase only)

## Future Enhancements
Additional improvements that could be made in follow-up PRs:
- Darker arrow color for higher contrast (#0D47A1 → #002171)
- Background highlight on sorted column header
- Subtle animation when sort changes