### PR TITLE
Add Google Drive logout functionality - Issue #32

### DIFF
--- a/CameraCopyTool/MainWindow.xaml
+++ b/CameraCopyTool/MainWindow.xaml
@@ -81,6 +81,20 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
+
+        <!-- Logout button specific style -->
+        <Style x:Key="LogoutButtonStyle" BasedOn="{StaticResource ActionButtonStyle}" TargetType="Button">
+            <Setter Property="Background" Value="#F44336"/>
+            <Setter Property="Foreground" Value="#FFFFFF"/>
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#E53935"/>
+                </Trigger>
+                <Trigger Property="IsPressed" Value="True">
+                    <Setter Property="Background" Value="#D32F2F"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
         
         <!-- Context menu for ListView items -->
         <ContextMenu x:Key="FileItemContextMenu">
@@ -405,7 +419,7 @@
                     </Button>
                 </StackPanel>
 
-                <!-- Right side: Settings and Help buttons -->
+                <!-- Right side: Settings, Logout, and Help buttons -->
                 <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
                     <Button Content="⚙️ Settings"
                             Command="{Binding OpenSettingsCommand}"
@@ -414,6 +428,29 @@
                         <Button.ToolTip>
                             <ToolTip Content="Configure application settings (font size, Google Drive, etc.)"
                                      Style="{StaticResource DynamicToolTip}"/>
+                        </Button.ToolTip>
+                    </Button>
+                    <Button Content="🚪 Logout"
+                            Command="{Binding LogoutCommand}"
+                            Style="{StaticResource LogoutButtonStyle}"
+                            Margin="0,0,10,0"
+                            Visibility="{Binding IsGoogleDriveConfigured, Converter={StaticResource BooleanToVisibilityConverter}}"
+                            IsEnabled="{Binding IsGoogleDriveAuthenticated}">
+                        <Button.ToolTip>
+                            <ToolTip FontSize="16">
+                                <ToolTip.Style>
+                                    <Style TargetType="ToolTip" BasedOn="{StaticResource {x:Type ToolTip}}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsGoogleDriveAuthenticated}" Value="True">
+                                                <Setter Property="Content" Value="Disconnect from Google Drive account"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding IsGoogleDriveAuthenticated}" Value="False">
+                                                <Setter Property="Content" Value="Sign in to Google Drive first to use logout"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ToolTip.Style>
+                            </ToolTip>
                         </Button.ToolTip>
                     </Button>
                     <Button Content="❓ How to Use"

--- a/CameraCopyTool/MainWindow.xaml.cs
+++ b/CameraCopyTool/MainWindow.xaml.cs
@@ -378,10 +378,13 @@ namespace CameraCopyTool
                         return;
                     }
 
-                    // Authentication successful - no MessageBox needed
-                    // Force refresh the status bar to show connected status
+                    // Authentication successful - update all related properties
                     _viewModel.OnPropertyChanged(nameof(MainViewModel.GoogleDriveStatus));
+                    _viewModel.OnPropertyChanged(nameof(MainViewModel.GoogleDriveUserEmail));
+                    _viewModel.OnPropertyChanged(nameof(MainViewModel.IsGoogleDriveAuthenticated));
                     System.Diagnostics.Debug.WriteLine($"Status bar updated: {_viewModel.GoogleDriveStatus}");
+                    System.Diagnostics.Debug.WriteLine($"User email: {_viewModel.GoogleDriveUserEmail}");
+                    System.Diagnostics.Debug.WriteLine($"IsAuthenticated: {_viewModel.IsGoogleDriveAuthenticated}");
                 }
 
                 // Show upload progress dialog

--- a/CameraCopyTool/Services/GoogleDriveService.cs
+++ b/CameraCopyTool/Services/GoogleDriveService.cs
@@ -189,13 +189,17 @@ namespace CameraCopyTool.Services
         {
             try
             {
-                if (File.Exists(_settings.CredentialsPath))
+                // FileDataStore stores tokens in subdirectories under CredentialsPath
+                // Delete the entire directory to clear all cached tokens
+                if (Directory.Exists(_settings.CredentialsPath))
                 {
-                    File.Delete(_settings.CredentialsPath);
+                    Directory.Delete(_settings.CredentialsPath, true);
                 }
 
                 _credential = null;
                 _driveService = null;
+                
+                System.Diagnostics.Debug.WriteLine($"Logout successful - deleted: {_settings.CredentialsPath}");
             }
             catch (Exception ex)
             {

--- a/CameraCopyTool/ViewModels/MainViewModel.cs
+++ b/CameraCopyTool/ViewModels/MainViewModel.cs
@@ -160,6 +160,7 @@ public class MainViewModel : ViewModelBase
         OpenSettingsCommand = new RelayCommand(_ => OpenSettings());
         ToggleHelpCommand = new RelayCommand(_ => ToggleHelpPanel());
         LogoutGoogleDriveCommand = new RelayCommand(_ => LogoutGoogleDrive());
+        LogoutCommand = new RelayCommand(_ => LogoutWithConfirmation());
 
         // Load saved settings from previous session
         _sourcePath = _settingsService.LastSourceFolder ?? string.Empty;
@@ -344,11 +345,21 @@ public class MainViewModel : ViewModelBase
     public bool IsGoogleDriveConfigured => _googleDriveService != null;
 
     /// <summary>
+    /// Gets a value indicating whether the user is authenticated with Google Drive.
+    /// </summary>
+    public bool IsGoogleDriveAuthenticated => _googleDriveService?.IsAuthenticated == true;
+
+    /// <summary>
     /// Gets the Google Drive authentication status message.
     /// </summary>
     public string GoogleDriveStatus => _googleDriveService?.IsAuthenticated == true
         ? "Connected to Google Drive"
         : "Not connected to Google Drive";
+
+    /// <summary>
+    /// Gets the authenticated Google Drive user's email address.
+    /// </summary>
+    public string? GoogleDriveUserEmail => _googleDriveService?.UserEmail;
 
     /// <summary>
     /// Gets the status bar icon (emoji) based on current state.
@@ -555,6 +566,12 @@ public class MainViewModel : ViewModelBase
     /// </summary>
     public ICommand LogoutGoogleDriveCommand { get; }
 
+    /// <summary>
+    /// Gets the command to logout from Google Drive with confirmation dialog.
+    /// Bound to the logout button in the main window.
+    /// </summary>
+    public ICommand LogoutCommand { get; }
+
     #endregion
 
     #region Command Handlers
@@ -674,12 +691,51 @@ public class MainViewModel : ViewModelBase
     {
         _googleDriveService?.Logout();
         OnPropertyChanged(nameof(GoogleDriveStatus));
-        
+        OnPropertyChanged(nameof(GoogleDriveUserEmail));
+        OnPropertyChanged(nameof(IsGoogleDriveAuthenticated));
+
         _dialogService.ShowMessage(
             "Disconnected from Google Drive.\n\nYou will need to sign in again to upload files.",
             "Logged Out",
             MessageBoxButton.OK,
             MessageBoxImage.Information);
+    }
+
+    /// <summary>
+    /// Shows a confirmation dialog and logs out from Google Drive if confirmed.
+    /// </summary>
+    private void LogoutWithConfirmation()
+    {
+        if (_googleDriveService == null)
+        {
+            return;
+        }
+
+        if (!_googleDriveService.IsAuthenticated)
+        {
+            _dialogService.ShowMessage(
+                "You are not currently signed in to Google Drive.",
+                "Not Connected",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+            return;
+        }
+
+        var userEmail = _googleDriveService.UserEmail ?? "unknown account";
+        var message = $"You are currently connected to Google Drive as:\n\n  {userEmail}\n\n" +
+                     $"If you log out, you will need to sign in again to upload files.\n\n" +
+                     $"Do you want to continue?";
+
+        var result = _dialogService.ShowMessage(
+            message,
+            "Confirm Logout",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        if (result == MessageBoxResult.Yes)
+        {
+            LogoutGoogleDrive();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #32 

Add Google Drive logout functionality - Issue #32
PR Description
## Description
Implements Google Drive logout functionality allowing users to disconnect from their current Google account and switch to a different account.

## Changes
- **Logout Button**: Red logout button (🚪) in main window toolbar between Settings and Help
- **Confirmation Dialog**: Shows account email and warns user they'll need to sign in again
- **Button States**:
  - Visible when Google Drive is configured
  - Disabled (grayed out) when not signed in
  - Enabled (red) when authenticated
- **Dynamic Tooltip**: Changes based on authentication state
- **Fixed Logout**: Properly deletes OAuth token directory (FileDataStore structure)

## Files Changed
| File | Changes |
|------|---------|
| `MainWindow.xaml` | Logout button with LogoutButtonStyle, dynamic tooltip |
| `MainWindow.xaml.cs` | Property change notifications after authentication |
| `GoogleDriveService.cs` | Fixed Logout() to delete entire credentials directory |
| `MainViewModel.cs` | IsGoogleDriveAuthenticated, GoogleDriveUserEmail properties, LogoutCommand |

## User Impact
- Users can now switch Google Drive accounts without clearing app data
- Proper logout ensures re-authentication is required
- Better UX with confirmation dialog showing account email

## Related Issues
- Closes #32

## Testing
1. Sign in to Google Drive (right-click file → Upload → Sign In)
2. Click logout button (🚪) → Confirm logout
3. Verify button is now disabled
4. Try to upload file → Sign In should require full authentication (not auto-sign-in)